### PR TITLE
Add Initial GitHub Workflow

### DIFF
--- a/.github/workflows/run-profile.yml
+++ b/.github/workflows/run-profile.yml
@@ -12,11 +12,13 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@master
-    - name: install chef
-      uses: actionshub/chef-install@main
-      with:
-        channel: current
-        project: inspec
+    # - name: install chef
+    #   uses: actionshub/chef-install@main
+    #   with:
+    #     channel: current
+    #     project: inspec
+    - name: Install InSpec as a Ruby Get-Command
+      run: gem install inspec
     - name: Print the environment
       run: 'dir env:'
     - name: Try to find InSpec

--- a/.github/workflows/run-profile.yml
+++ b/.github/workflows/run-profile.yml
@@ -16,26 +16,19 @@ jobs:
       uses: actions/checkout@master
     - name: install chef
       uses: actionshub/chef-install@main
-      # with:
-      #   channel: current
-      #   project: inspec
     - name: Check InSpec version
       run: inspec version
     - name: Run InSpec
-      run: inspec exec . --reporter=cli
-
-    # - name: Print the environment
-    #   run: 'dir env:'
-
-    # - name: Try to find InSpec
-    #   run: Get-Command inspec
-    # - name: List ruby file
-    #   run: ls C:\Ruby31-x64\bin\
-    # - name: Print path
-    #   run: '$env:PATH'
-    # - name: Try to install ruby dev kit
-    #   run: ridk install
-    # - name: Install InSpec as a Ruby Gem
-    #   run: gem install inspec-bin
-    # - name: Install Inspec using windows command
-    #   run: . { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -project inspec
+      run: 'inspec exec . --reporter=json:results.json'
+    - name: Display the results summary
+      uses: mitre/saf_action@v1
+      with:
+        command_string: 'view summary -i results.json'
+    - name: Ensure the scan meets the results threshold
+      uses: mitre/saf_action@v1
+      with:
+        command_string: 'validate threshold -i results.json -F threshold.yml'
+    - name: Save Test Result JSON
+      uses: actions/upload-artifact@v2
+      with:
+        path: results.json

--- a/.github/workflows/run-profile.yml
+++ b/.github/workflows/run-profile.yml
@@ -15,17 +15,17 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@master
+    - name: install chef
+      uses: actionshub/chef-install@main
+      with:
+        channel: current
+        project: inspec
     - name: Print path
       run: '$env:PATH'
-    # - name: install chef
-    #   uses: actionshub/chef-install@main
-    #   with:
-    #     channel: current
-    #     project: inspec
-    - name: Try to install ruby dev kit
-      run: ridk install
-    - name: Install InSpec as a Ruby Gem
-      run: gem install inspec-bin
+    # - name: Try to install ruby dev kit
+    #   run: ridk install
+    # - name: Install InSpec as a Ruby Gem
+    #   run: gem install inspec-bin
     # - name: Install Inspec using windows command
     #   run: . { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -project inspec
     - name: Print the environment

--- a/.github/workflows/run-profile.yml
+++ b/.github/workflows/run-profile.yml
@@ -9,6 +9,8 @@ jobs:
   my-job:
     name: Validate my profile
     runs-on: windows-2022
+    env:
+      CHEF_LICENSE: accept-silent
     steps:
     - name: Check out code
       uses: actions/checkout@master
@@ -18,7 +20,7 @@ jobs:
     #     channel: current
     #     project: inspec
     - name: Install InSpec as a Ruby Get-Command
-      run: gem install inspec
+      run: gem install inspec-bin
     - name: Print the environment
       run: 'dir env:'
     - name: Try to find InSpec

--- a/.github/workflows/run-profile.yml
+++ b/.github/workflows/run-profile.yml
@@ -22,12 +22,12 @@ jobs:
     #   with:
     #     channel: current
     #     project: inspec
-    # - name: Install InSpec as a Ruby Gem
-    #   run: gem install inspec-bin
-    - name: Install Inspec using windows command
-      run: . { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -project inspec
-    - name: Install Inspec-bin using windows command
-      run: . { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -project inspec-bin
+    - name: Try to install ruby dev kit
+      run: ridk install
+    - name: Install InSpec as a Ruby Gem
+      run: gem install inspec-bin
+    # - name: Install Inspec using windows command
+    #   run: . { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -project inspec
     - name: Print the environment
       run: 'dir env:'
     - name: Check InSpec version

--- a/.github/workflows/run-profile.yml
+++ b/.github/workflows/run-profile.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   my-job:
     name: Validate my profile
-    timeout-minutes: NUMBER
+    timeout-minutes: 30
     runs-on: windows-2022
     env:
       CHEF_LICENSE: accept-silent

--- a/.github/workflows/run-profile.yml
+++ b/.github/workflows/run-profile.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Check InSpec version
       run: inspec version
     - name: Run InSpec
-      run: 'inspec exec . --reporter=cli json:results.json'
+      run: 'inspec exec . --reporter=cli json:results.json | true'
     - name: Display the results summary
       uses: mitre/saf_action@v1
       with:

--- a/.github/workflows/run-profile.yml
+++ b/.github/workflows/run-profile.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Check InSpec version
       run: inspec version
     - name: Run InSpec
-      run: 'inspec exec . --reporter=json:results.json'
+      run: 'inspec exec . --reporter json:results.json'
     - name: Display the results summary
       uses: mitre/saf_action@v1
       with:

--- a/.github/workflows/run-profile.yml
+++ b/.github/workflows/run-profile.yml
@@ -19,8 +19,10 @@ jobs:
     #   with:
     #     channel: current
     #     project: inspec
-    - name: Install InSpec as a Ruby Get-Command
-      run: gem install inspec-bin
+    # - name: Install InSpec as a Ruby Gem
+    #   run: gem install inspec-bin
+    - name: Install Inspec using windows command
+      run: . { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -project inspec
     - name: Print the environment
       run: 'dir env:'
     - name: Try to find InSpec

--- a/.github/workflows/run-profile.yml
+++ b/.github/workflows/run-profile.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
+    branches: [ main ]
 
 jobs:
   my-job:

--- a/.github/workflows/run-profile.yml
+++ b/.github/workflows/run-profile.yml
@@ -30,6 +30,8 @@ jobs:
     #   run: . { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -project inspec
     - name: Print the environment
       run: 'dir env:'
+    - name: List ruby file
+      run: ls C:\Ruby31-x64\bin\
     - name: Check InSpec version
       run: inspec version
     - name: Try to find InSpec

--- a/.github/workflows/run-profile.yml
+++ b/.github/workflows/run-profile.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   my-job:
     name: Validate my profile
-    timeout-minutes: 30
     runs-on: windows-2022
     env:
       CHEF_LICENSE: accept-silent
@@ -17,24 +16,26 @@ jobs:
       uses: actions/checkout@master
     - name: install chef
       uses: actionshub/chef-install@main
-      with:
-        channel: current
-        project: inspec
-    - name: Print path
-      run: '$env:PATH'
+      # with:
+      #   channel: current
+      #   project: inspec
+    - name: Check InSpec version
+      run: inspec version
+    - name: Run InSpec
+      run: inspec exec . --reporter=cli
+
+    # - name: Print the environment
+    #   run: 'dir env:'
+
+    # - name: Try to find InSpec
+    #   run: Get-Command inspec
+    # - name: List ruby file
+    #   run: ls C:\Ruby31-x64\bin\
+    # - name: Print path
+    #   run: '$env:PATH'
     # - name: Try to install ruby dev kit
     #   run: ridk install
     # - name: Install InSpec as a Ruby Gem
     #   run: gem install inspec-bin
     # - name: Install Inspec using windows command
     #   run: . { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -project inspec
-    - name: Print the environment
-      run: 'dir env:'
-    - name: List ruby file
-      run: ls C:\Ruby31-x64\bin\
-    - name: Check InSpec version
-      run: inspec version
-    - name: Try to find InSpec
-      run: Get-Command inspec
-    - name: Run InSpec
-      run: inspec exec . --reporter=cli

--- a/.github/workflows/run-profile.yml
+++ b/.github/workflows/run-profile.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Check InSpec version
       run: inspec version
     - name: Run InSpec
-      run: 'inspec exec . --reporter=cli json:results.json | true'
+      run: 'inspec exec . --reporter=cli json:results.json || true'
     - name: Display the results summary
       uses: mitre/saf_action@v1
       with:

--- a/.github/workflows/run-profile.yml
+++ b/.github/workflows/run-profile.yml
@@ -22,10 +22,12 @@ jobs:
     #   with:
     #     channel: current
     #     project: inspec
-    - name: Install InSpec as a Ruby Gem
-      run: gem install inspec-bin
-    # - name: Install Inspec using windows command
-    #   run: . { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -project inspec
+    # - name: Install InSpec as a Ruby Gem
+    #   run: gem install inspec-bin
+    - name: Install Inspec using windows command
+      run: . { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -project inspec
+    - name: Install Inspec-bin using windows command
+      run: . { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -project inspec-bin
     - name: Print the environment
       run: 'dir env:'
     - name: Check InSpec version

--- a/.github/workflows/run-profile.yml
+++ b/.github/workflows/run-profile.yml
@@ -17,7 +17,9 @@ jobs:
       with:
         channel: current
         project: inspec
-    - name: Where am I?
-      run: ls C:\opscode\chef-workstation\
+    - name: Print the environment
+      run: 'dir env:'
+    - name: Try to find InSpec
+      run: Get-Command inspec
     - name: Run InSpec
-      run: C:\opscode\chef-workstation\inspec exec . --reporter=cli
+      run: inspec exec . --reporter=cli

--- a/.github/workflows/run-profile.yml
+++ b/.github/workflows/run-profile.yml
@@ -17,5 +17,7 @@ jobs:
       with:
         channel: current
         project: inspec
+    - name: Where am I?
+      run: ls C:\opscode\chef-workstation\
     - name: Run InSpec
-      run: inspec exec . --reporter=cli
+      run: C:\opscode\chef-workstation\inspec exec . --reporter=cli

--- a/.github/workflows/run-profile.yml
+++ b/.github/workflows/run-profile.yml
@@ -1,0 +1,21 @@
+name: Run InSpec Profile
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  my-job:
+    name: Validate my profile
+    runs-on: windows-2022
+    steps:
+    - name: Check out code
+      uses: actions/checkout@master
+    - name: install chef
+      uses: actionshub/chef-install@main
+      with:
+        channel: current
+        project: inspec
+    - name: Run InSpec
+      run: inspec exec . --reporter=cli

--- a/.github/workflows/run-profile.yml
+++ b/.github/workflows/run-profile.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Check InSpec version
       run: inspec version
     - name: Run InSpec
-      run: 'inspec exec . --reporter json:results.json'
+      run: 'inspec exec . --reporter=cli json:results.json'
     - name: Display the results summary
       uses: mitre/saf_action@v1
       with:

--- a/.github/workflows/run-profile.yml
+++ b/.github/workflows/run-profile.yml
@@ -8,23 +8,28 @@ on:
 jobs:
   my-job:
     name: Validate my profile
+    timeout-minutes: NUMBER
     runs-on: windows-2022
     env:
       CHEF_LICENSE: accept-silent
     steps:
     - name: Check out code
       uses: actions/checkout@master
+    - name: Print path
+      run: '$env:PATH'
     # - name: install chef
     #   uses: actionshub/chef-install@main
     #   with:
     #     channel: current
     #     project: inspec
-    # - name: Install InSpec as a Ruby Gem
-    #   run: gem install inspec-bin
-    - name: Install Inspec using windows command
-      run: . { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -project inspec
+    - name: Install InSpec as a Ruby Gem
+      run: gem install inspec-bin
+    # - name: Install Inspec using windows command
+    #   run: . { iwr -useb https://omnitruck.chef.io/install.ps1 } | iex; install -project inspec
     - name: Print the environment
       run: 'dir env:'
+    - name: Check InSpec version
+      run: inspec version
     - name: Try to find InSpec
       run: Get-Command inspec
     - name: Run InSpec

--- a/threshold.yml
+++ b/threshold.yml
@@ -1,0 +1,2 @@
+---
+compliance.min: 0


### PR DESCRIPTION
Added an initial GitHub workflow that will run the InSpec profile against an unhardened Windows GitHub runner. 
The results are validated against a threshold which is currently set to pass for everything because it passes for anything equal or over 0 percent compliance.