### PR TITLE
Update workflow to use artifact actions v4

### DIFF
--- a/.github/workflows/run-profile.yml
+++ b/.github/workflows/run-profile.yml
@@ -30,6 +30,6 @@ jobs:
       with:
         command_string: 'validate threshold -i results.json -F threshold.yml'
     - name: Save Test Result JSON
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         path: results.json

--- a/.github/workflows/run-profile.yml
+++ b/.github/workflows/run-profile.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Ensure the scan meets the results threshold
       uses: mitre/saf_action@v1
       with:
-        command_string: 'validate threshold -i results.json -F threshold.yml'
+        command_string: 'validate threshold -i results.json -T threshold.yml'
     - name: Save Test Result JSON
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
Updating artifact actions v3 to v4 since v3 will be deprecated 1/30/2025